### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ curl -sL https://cdn.jsdelivr.net/gh/proxifly/free-proxy-list@main/proxies/count
 ```
 
 ## ✨ Star history
-[![Star History Chart](https://api.star-history.com/svg?repos=proxifly/free-proxy-list&type=Date)](https://www.star-history.com/#proxifly/free-proxy-list&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=proxifly/free-proxy-list&type=Date)](https://star-history.dera.page/#proxifly/free-proxy-list&type=Date)
 
 ## 🧸 Contributing
 Contributions are welcome, and they are greatly appreciated! Every


### PR DESCRIPTION
The star history chart in the README is currently broken because GitHub restricted its stargazer API. This change updates the chart to a working alternative so the repository star history renders correctly again.